### PR TITLE
Implement join-output option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ optional arguments:
   --version   show version and exit
   --import IMPORT  modules to import
   --sort-keys, -S  sort keys in objects when the command print it
+  --join-output, -j  do not show newlines
 
 
 Example

--- a/jqp/__init__.py
+++ b/jqp/__init__.py
@@ -20,7 +20,8 @@ def _exit(error, return_code, message):
     sys.exit(return_code)
 
 
-def run(in_io, out_io, cmd, imports=[], sort_keys=False, raw_output=False):
+def run(in_io, out_io, cmd, imports=[], sort_keys=False, raw_output=False,
+        join_output=False):
     environment = {}
     for mod_name in imports:
         try:
@@ -53,7 +54,8 @@ def run(in_io, out_io, cmd, imports=[], sort_keys=False, raw_output=False):
             except Exception as e:
                 _exit(e, 3, 'Cannot dump result: line %d' % line_no)
 
-        out_io.write('\n')
+        if not join_output:
+            out_io.write('\n')
 
 
 def main():
@@ -71,8 +73,12 @@ def main():
     parser.add_argument(
         '--raw-output', '-r', action='store_true',
         help='when a result is string, the command shows a raw string')
+    parser.add_argument(
+        '--join-output', '-j', action='store_true',
+        help='do not show newlines')
 
     args = parser.parse_args()
 
     run(sys.stdin, sys.stdout, args.cmd, imports=getattr(args, 'import'),
-        sort_keys=args.sort_keys, raw_output=args.raw_output)
+        sort_keys=args.sort_keys, raw_output=args.raw_output,
+        join_output=args.join_output)

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -39,6 +39,13 @@ class RunTest(unittest.TestCase):
         jqp.run(inputs, outputs, '"a"', raw_output=True)
         self.assertEqual(outputs.getvalue(), 'a\n')
 
+    def test_join_output(self):
+        inputs = StringIO('''1
+2''')
+        outputs = StringIO()
+        jqp.run(inputs, outputs, 'j', join_output=True)
+        self.assertEqual(outputs.getvalue(), '12')
+
     def test_parse_error(self):
         inputs = StringIO('invalid\n')
         outputs = StringIO()


### PR DESCRIPTION
fix #24 
Note that the original jq works in raw mode when --join-output is given.
