### PR TITLE
Support --ascii-output option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ optional arguments:
   -h, --help  show this help message and exit
   --version   show version and exit
   --import IMPORT  modules to import
+  --ascii-output, -a  with this option, jqp ensures ASCII output
   --sort-keys, -S  sort keys in objects when the command print it
   --raw-input, -R  pass each line text as a string instead of parsing it as JSON
   --raw-output, -r   when a result is string, the command shows a raw string

--- a/jqp/__init__.py
+++ b/jqp/__init__.py
@@ -54,7 +54,8 @@ def run(in_io, out_io, cmd, imports=[], sort_keys=False, raw_input_mode=False,
         else:
             try:
                 json.dump(
-                    out, out_io, ensure_ascii=ascii_output, sort_keys=sort_keys)
+                    out, out_io, ensure_ascii=ascii_output,
+                    sort_keys=sort_keys)
             except Exception as e:
                 _exit(e, 3, 'Cannot dump result: line %d' % line_no)
 

--- a/jqp/__init__.py
+++ b/jqp/__init__.py
@@ -21,7 +21,7 @@ def _exit(error, return_code, message):
 
 
 def run(in_io, out_io, cmd, imports=[], sort_keys=False, raw_input_mode=False,
-        raw_output=False, join_output=False):
+        raw_output=False, join_output=False, ascii_output=True):
     environment = {}
     for mod_name in imports:
         try:
@@ -53,7 +53,8 @@ def run(in_io, out_io, cmd, imports=[], sort_keys=False, raw_input_mode=False,
             out_io.write(out)
         else:
             try:
-                json.dump(out, out_io, sort_keys=sort_keys)
+                json.dump(
+                    out, out_io, ensure_ascii=ascii_output, sort_keys=sort_keys)
             except Exception as e:
                 _exit(e, 3, 'Cannot dump result: line %d' % line_no)
 
@@ -77,6 +78,9 @@ def main():
         '--raw-input', '-R', action='store_true',
         help='pass each line text as a string instead of parsing it as JSON')
     parser.add_argument(
+        '--ascii-output', '-a', action='store_true',
+        help='with this option, jqp ensures ASCII output')
+    parser.add_argument(
         '--raw-output', '-r', action='store_true',
         help='when a result is string, the command shows a raw string')
     parser.add_argument(
@@ -87,4 +91,5 @@ def main():
 
     run(sys.stdin, sys.stdout, args.cmd, imports=getattr(args, 'import'),
         sort_keys=args.sort_keys, raw_input_mode=args.raw_input,
-        raw_output=args.raw_output, join_output=args.join_output)
+        raw_output=args.raw_output, join_output=args.join_output,
+        ascii_output=args.ascii_output)

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -52,6 +52,15 @@ class RunTest(unittest.TestCase):
         jqp.run(inputs, outputs, 'j', join_output=True)
         self.assertEqual(outputs.getvalue(), '12')
 
+    def test_ascii(self):
+        # This command ignores input
+        inputs = StringIO('''1
+''')
+        outputs = StringIO()
+        # This is a Japanese character
+        jqp.run(inputs, outputs, u'"\u3042"', ascii_output=True)
+        self.assertEqual(outputs.getvalue(), '"\\u3042"\n')
+
     def test_parse_error(self):
         inputs = StringIO('invalid\n')
         outputs = StringIO()


### PR DESCRIPTION
With `--ascii-output` or `-a` option, jqp ensures ascii output.